### PR TITLE
Use python3 for git-sync-deps

### DIFF
--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is needed on a clean Crostini install, if I want to run as ./tools/git-sync-deps

Otherwise I get a "ImportError: No module named builtins"